### PR TITLE
Update group

### DIFF
--- a/src/main/cpp/loops/UpdateGroup.cpp
+++ b/src/main/cpp/loops/UpdateGroup.cpp
@@ -1,0 +1,16 @@
+#include "loops/UpdateGroup.h"
+
+using namespace wml::loops;
+
+void UpdateGroup::Register(LoopSystem *loopSystem, bool dtPriority) {
+  if (dtPriority) Register(std::bind(&LoopSystem::UpdateOnce, loopSystem));
+  else Register(std::bind(&LoopSystem::Update, loopSystem, _dt));
+}
+
+void UpdateGroup::Register(std::function<void(double)> func) {
+  _funcs.push_back(func);
+}
+
+void UpdateGroup::Update(double dt) {
+  for (auto func : _funcs) func(dt);
+}

--- a/src/main/cpp/loops/UpdateGroup.cpp
+++ b/src/main/cpp/loops/UpdateGroup.cpp
@@ -14,3 +14,10 @@ void UpdateGroup::Register(std::function<void(double)> func) {
 void UpdateGroup::Update(double dt) {
   for (auto func : _funcs) func(dt);
 }
+
+
+void UpdateGroup::operator()() { UpdateOnce(); }
+void UpdateGroup::operator()(double dt) { Update(dt); }
+
+UpdateGroup& UpdateGroup::operator+=(LoopSystem *rhs) { Register(rhs); return *this; }
+UpdateGroup& UpdateGroup::operator+=(std::function<void(double)> rhs) { Register(rhs); return *this; }

--- a/src/main/include/loops/UpdateGroup.h
+++ b/src/main/include/loops/UpdateGroup.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <functional>
+#include <vector>
+
+#include "loops/LoopSystem.h"
+
+namespace wml {
+  namespace loops {
+    static auto _dt = std::placeholders::_1;
+
+    class UpdateGroup : public LoopSystem {
+     public:
+      void Register(LoopSystem *loopSystem, bool dtPriority = false);
+      void Register(std::function<void(double)> func);
+
+      virtual void Update(double dt) override;
+
+     private:
+      std::vector<std::function<void(double)>> _funcs;
+    };
+  } // ns loops
+} // ns wml

--- a/src/main/include/loops/UpdateGroup.h
+++ b/src/main/include/loops/UpdateGroup.h
@@ -16,6 +16,15 @@ namespace wml {
 
       virtual void Update(double dt) override;
 
+
+      // operators, because why not
+
+      void operator()();
+      void operator()(double dt);
+
+      UpdateGroup& operator+=(LoopSystem *rhs); // uses default dtPriority
+      UpdateGroup& operator+=(std::function<void(double)> rhs);
+
      private:
       std::vector<std::function<void(double)>> _funcs;
     };


### PR DESCRIPTION
Allows anything that can be `Update()`ed to be 'grouped together'. Support for either `wml::loops::LoopSystem*`s or `std::function<void(double)>`s.

Note that since `wml::loops::UpdateGroup` implements `LoopSystem`, it can in theory be passed to itself. The code has no check for this, and this would cause an infinite loop that will crash your code as soon as you call `UpdateGroup::Update`. *Don't do it*.

Also you can schedule it to run automatically the with `LoopSystem::StartLoop(int hz)`.

#### Usage:
```cpp
// init:
wml::loops::UpdateGroup updateGroup;

// grouping:
updateGroup.Register(exampleGroupableThing);
// or (identical)
updateGroup += exampleGroupableThing;

// updating (for some 'dt'):
updateGroup.Update(dt);
// or (identical)
updateGroup(dt);

// updating (calc.s 'dt' itself):
updateGroup.UpdateOnce();
// or (identical)
updateGroup();
```

To add a `wml::loops:LoopSystem`:
```cpp
wml::actuators::Compressor compressor; // any type of LoopSystem will work

updateGroup += &compressor;

// Optional second parameter (default: false) makes the LoopSystem calculate `dt` itself
// when called - increases update time slightly, but provides more accurate `dt` values.
// Not recommended for anything that doesn't need to be *incredibly* accurate.
updateGroup.Register(&compressor, true);
```

To add a `std::function<void(double)>`:
```cpp
// adding a function:
void someFunctionThatNeedsToBeRunALot(double dt) { std::cout << dt << std::endl; }
void someOtherFunction() { std::cout << std::endl; }

updateGroup += someFunctionThatNeedsToBeRunALot;
updateGroup += std::bind(someOtherFunction);

// note that the call to `std::bind` in this case is to make `someOtherFunction`
// (signature `void()`) appear as `void(double)`, and as such is not required
// for `someFunctionThatNeedsToBeRunALot`, although can still be used as such:
updateGroup += std::bind(someFunctionThatNeedsToBeRunALot, _dt); // _dt = wml::loops::_dt = std::placeholders::_1


// adding a method:
class A {
 public:
  static void func1() { std::cout << "1" << std::endl; };
  static void func2(double dt) { std::cout << "2 " << dt << std::endl; };

  void func3() { std::cout << "3" << std::endl; };
  void func4(double dt) { std::cout << "4 " << dt << std::endl; };
};

updateGroup += std::bind(A::func1);
updateGroup += A::func2; // or `std::bind(A::func2, _dt)`

A inst;
updateGroup += std::bind(&A::func3, &inst);
updateGroup += std::bind(&A::func4, &inst, _dt);
```