### PR TITLE
Fix gradle suport

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,26 @@ plugins {
 }
 ```
 
-- Inside `teams.gradle` (or whatever you choose to call it) add:
+- Inside your project file (e.g. `teams.gradle`) add:
 ```gradle
+def includeSrcInIncludeRoot = false
+def includeDesktopSupport = false
+
+def includeWMLRevSupport = false
+
+project(':wml').ext.setProperty('includeSrcInIncludeRoot', includeSrcInIncludeRoot)
+project(':wml').ext.setProperty('includeDesktopSupport', includeDesktopSupport)
+project(':wml').ext.setProperty('includeWMLRevSupport', includeWMLRevSupport)
+
+// ...
+
 wpi.deps.vendor.loadFrom(project(':wml'))
+
+// ...
 
 model {
   components {
-    "frcUserProgram${project.name}"(NativeExecutableSpec) {
+    frcUserProgram(NativeExecutableSpec) {
       // ...
       binaries.all {
         lib project: ':wml', library: 'wml', linkage: 'static'
@@ -31,9 +44,8 @@ model {
       // ...
     }
   }
-
   testSuites {
-    "frcUserProgramTest${project.name}"(GoogleTestTestSuiteSpec) {
+    frcUserProgramTest(GoogleTestTestSuiteSpec) {
       // ...
       binaries.all {
         lib project: ':wml', library: 'wml', linkage: 'static'
@@ -43,6 +55,9 @@ model {
   }
 }
 
+// ...
+
+// optional:
 if (!project.hasProperty('no-wml-check'))
   tasks.check.dependsOn(':wml:check') 
 ```
@@ -63,4 +78,4 @@ Or read the source code of the library; it has a few comments inside there. But 
 That being said, if you have an issue or question feel free to contact us. We don't have lives... we're programmers.
 
 
-<sub><sup>readme written by [@CJBuchel](https://github.com/CJBuchel), 9/01/20</sup></sub>
+<sub><sup>readme written by [@CJBuchel](https://github.com/CJBuchel), 4/03/20</sup></sub>

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,10 @@ plugins {
   id 'org.ysb33r.doxygen'
 }
 
-// Override these in your root gradle file
-def includeSrcInIncludeRoot = false
-def includeDesktopSupport = false
-
-// logger.warn(String.valueOf(includeSrcInIncludeRoot))
-// logger.warn(String.valueOf(includeDesktopSupport))
+// Override these in your project gradle file
+includeSrcInIncludeRoot = project.findProperty('includeSrcInIncludeRoot') ?: false
+includeDesktopSupport = project.findProperty('includeDesktopSupport') ?: false
+includeWMLRevSupport = project.findProperty('includeWMLRevSupport') ?: false
 
 model {
   components {
@@ -23,12 +21,24 @@ model {
       sources.cpp {
         source {
           srcDir 'src/main/cpp'
+
+          if (includeWMLRevSupport) {
+            srcDir 'src/rev/cpp'
+          }
+
           include '**/*.cpp', '**/*.cc'
         }
         exportedHeaders {
           srcDir 'src/main/include'
           if (includeSrcInIncludeRoot) {
             srcDir 'src/main/cpp'
+          }
+
+          if (includeWMLRevSupport) {
+            srcDir 'src/rev/include'
+            if (includeSrcInIncludeRoot) {
+              srcDir 'src/rev/cpp'
+            }
           }
         }
       }
@@ -65,4 +75,5 @@ doxygen {
   generate_html true
   javadoc_autobrief true
   source project.file('src/main/include')
+  source project.file('src/rev/include')
 }


### PR DESCRIPTION
- See [this commit](https://github.com/UWA-FRC/2020-InfiniteRecharge/pull/11/commits/dcd7a793a80b4fa7326d170b0c0c13d6831a488c)

~~Note that #23 is even moreso the case now.~~

Usage Instructions:
- Include wml in your settings file
- Set includeSrcInIncludeRoot, includeDesktopSupport, and/or includeWMLRevSupport (in your project file)
- Load the wml deps in your project file (`wpi.deps.vendor.loadFrom(project(':wml'))`)
- Add wml as a binary to your main and test code (`binaries.all { lib project: ':wml', library: 'wml', linkage: 'static' }`)

Edit:
Resolves #23