### PR TITLE
Fixed vendordep client side through vscode (http/https)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@
 - The vendordep JSON files come in multiple parts and all are optional. E.g `WML-Core` for the core components. `WML-Rev` for Rev support (Neo Motor's). And `UDP_TransferNT`, used for point to point networking with UDP. Mainly used for communications to and from [CJ-Vision](https://github.com/wml-frc/CJ-Vision) platforms.
 
 - JSON URLS
-	- WML-Core: https://buchel.family/repository/wml/first/WML-Core/WML-Core-Deps/latest/WML-Core-Deps-latest.json
-	- WML-Rev: https://buchel.family/repository/wml/first/WML-Rev/WML-Rev-Deps/latest/WML-Rev-Deps-latest.json
-	- UDP_TransferNT: https://buchel.family/repository/wml/first/UDP_TransferNT/UDP_TransferNT-Deps/latest/UDP_TransferNT-Deps-latest.json
+	- WML-Core: http://buchel.family/repository/wml/first/WML-Core/WML-Core-Deps/latest/WML-Core-Deps-latest.json
+	- WML-Rev: http://buchel.family/repository/wml/first/WML-Rev/WML-Rev-Deps/latest/WML-Rev-Deps-latest.json
+	- UDP_TransferNT: http://buchel.family/repository/wml/first/UDP_TransferNT/UDP_TransferNT-Deps/latest/UDP_TransferNT-Deps-latest.json
 
-- Replace both occurrences of `latest` with a version for a specific version. E.g https://buchel.family/repository/wml/first/WML-Core/WML-Core-Deps/2021.3.1/WML-Core-Deps-2021.3.1.json
+- Replace both occurrences of `latest` with a version for a specific version. E.g http://buchel.family/repository/wml/first/WML-Core/WML-Core-Deps/2021.3.1/WML-Core-Deps-2021.3.1.json
+
+- Note that when adding the vendordeps through vscode it must be `http` not `https`. As this may cause security issues on some devices. If downloading manually by placing the vendordep json into the `vendordep` folder then this does not apply.
 
 ## WML As Submodule
 

--- a/config.gradle
+++ b/config.gradle
@@ -1,6 +1,7 @@
 ext {
-	// Maven URL
-	mavenURL = "https://buchel.family/repository/wml"
+	// Maven URLs
+	mavenPublishURL = "https://buchel.family/repository/wml" // maven only publishes via secure lines
+	mavenClientURL = "http://buchel.family/repository/wml" // client maven only works without ssl security
 	outputFolder = file("$rootProject.buildDir/outputs")
 
 	licenseFile = file("$rootDir/LICENSE")

--- a/shared/mainBuild.gradle
+++ b/shared/mainBuild.gradle
@@ -27,6 +27,27 @@ ext {
 	} else {
 		nullBuild = false
 	}
+
+	if (project.hasProperty("supportedPlatforms")) {
+		println "${nativeName}: Override Supported Platforms"
+		println "${nativeName}. Compiling for platforms: ${supportedPlatforms}"
+	} else {
+		println "${nativeName}: Using Default Supported Platforms"
+
+		// Assume if zipping src it has binaries
+		if (srcZip) {
+			supportedPlatforms = [
+				"linuxx86-64",
+				"windowsx86-64",
+				"osxx86-64",
+				"linuxathena",
+			]
+		} else {
+			supportedPlatforms = []
+		}
+
+		println "${nativeName}. Compiling for platforms: ${supportedPlatforms}"
+	}
 }
 
 // BINARY PUBLISHER & ARTIFACTS

--- a/shared/publish.gradle
+++ b/shared/publish.gradle
@@ -10,12 +10,13 @@ publishing {
 			if (localMaven) {
 				println "${nativeName}: Using Local Maven"
 				name = "all_wml_maven"
-				mavenURL = "${rootProject.buildDir}/maven"
-				url = mavenURL
+				mavenPublishURL = "${rootProject.buildDir}/maven"
+				mavenClientURL = mavenPublishURL
+				url = mavenPublishURL
 			} else {
 				println "${nativeName}: Using Remote maven - I sure hope you know what your doing"
-				println "Publishing to: ${mavenURL}"
-				url = mavenURL
+				println "Publishing to: ${mavenPublishURL}"
+				url = mavenPublishURL
 				credentials {
 					username = project.getProperty("publish_user")
 					password = project.getProperty("publish_pass")

--- a/shared/vendor.gradle
+++ b/shared/vendor.gradle
@@ -7,10 +7,10 @@ Map<String, Object> vendorJson() {
 		version: artifactVersion,
 		uuid: "${artifactUUID}",
 		mavenUrls: [
-			mavenURL
+			mavenClientURL
 		],
 
-		jsonUrl: "${mavenURL}/${artifactGroupID_URL}/${depsName}/${artifactVersion}/${depsName}-${artifactVersion}.json",
+		jsonUrl: "${mavenClientURL}/${artifactGroupID_URL}/${depsName}/${artifactVersion}/${depsName}-${artifactVersion}.json",
 		cppDependencies: [
 			[
 				groupId: artifactGroupID,
@@ -20,12 +20,7 @@ Map<String, Object> vendorJson() {
 				headerClassifier: "headers",
 				sharedLibrary: true,
 				skipInvalidPlatforms: true,
-				binaryPlatforms: [
-					"linuxx86-64",
-					"windowsx86-64",
-					"osxx86-64",
-					"linuxathena",
-				]
+				binaryPlatforms: supportedPlatforms
 			]
 		]
 	]
@@ -38,10 +33,10 @@ Map<String, Object> vendorJsonLatest() {
 		version: artifactVersion,
 		uuid: "${artifactUUID}",
 		mavenUrls: [
-			mavenURL
+			mavenClientURL
 		],
 
-		jsonUrl: "${mavenURL}/${artifactGroupID_URL}/${depsName}/latest/${depsName}-latest.json",
+		jsonUrl: "${mavenClientURL}/${artifactGroupID_URL}/${depsName}/latest/${depsName}-latest.json",
 		cppDependencies: [
 			[
 				groupId: artifactGroupID,
@@ -52,12 +47,7 @@ Map<String, Object> vendorJsonLatest() {
 				sourcesClassifier: "sources",
 				sharedLibrary: true,
 				skipInvalidPlatforms: true,
-				binaryPlatforms: [
-					"linuxx86-64",
-					"windowsx86-64",
-					"osxx86-64",
-					"linuxathena",
-				]
+				binaryPlatforms: supportedPlatforms
 			]
 		]
 	]


### PR DESCRIPTION
**What this PR does**  
Replaces the maven url in the .json files with `http` and uses `https` for publishing url for security and easier access for client devices

### Note The Two URL's
- Publish URL: mavenPublishURL = "https://buchel.family/repository/wml"
- Client/JSON URL: mavenClientURL = "http://buchel.family/repository/wml"

**What does it fix/add?**  
Fixes vendordeps not being downloaded with .json file through vscode