### PR TITLE
uses https for maven url (GradleRIO update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@
 - The vendordep JSON files come in multiple parts and all are optional. E.g `WML-Core` for the core components. `WML-Rev` for Rev support (Neo Motor's). And `UDP_TransferNT`, used for point to point networking with UDP. Mainly used for communications to and from [CJ-Vision](https://github.com/wml-frc/CJ-Vision) platforms.
 
 - JSON URLS
-	- WML-Core: http://buchel.family/repository/wml/first/WML-Core/WML-Core-Deps/latest/WML-Core-Deps-latest.json
-	- WML-Rev: http://buchel.family/repository/wml/first/WML-Rev/WML-Rev-Deps/latest/WML-Rev-Deps-latest.json
-	- UDP_TransferNT: http://buchel.family/repository/wml/first/UDP_TransferNT/UDP_TransferNT-Deps/latest/UDP_TransferNT-Deps-latest.json
+	- WML-Core: https://buchel.family/repository/wml/first/WML-Core/WML-Core-Deps/latest/WML-Core-Deps-latest.json
+	- WML-Rev: https://buchel.family/repository/wml/first/WML-Rev/WML-Rev-Deps/latest/WML-Rev-Deps-latest.json
+	- UDP_TransferNT: https://buchel.family/repository/wml/first/UDP_TransferNT/UDP_TransferNT-Deps/latest/UDP_TransferNT-Deps-latest.json
 
-- Replace both occurrences of `latest` with a version for a specific version. E.g http://buchel.family/repository/wml/first/WML-Core/WML-Core-Deps/2021.3.1/WML-Core-Deps-2021.3.1.json
+- Replace both occurrences of `latest` with a version for a specific version. E.g https://buchel.family/repository/wml/first/WML-Core/WML-Core-Deps/2021.3.2/WML-Core-Deps-2021.3.2.json
 
-- Note that when adding the vendordeps through vscode it must be `http` not `https`. As this may cause security issues on some devices. If downloading manually by placing the vendordep json into the `vendordep` folder then this does not apply.
+- Note that when adding the vendordeps through vscode with older versions (gradlerio `2021.2.1`) it must be `http` not `https`. As this may cause security issues on some devices. If downloading manually by placing the vendordep json into the `vendordep` folder then this does not apply.
 
 ## WML As Submodule
 
@@ -77,16 +77,15 @@ model {
 - You can view the generated documentation for each project via `https://buchel.family/repository/wml/first/<library>/<library>-Docs/<version>/<library>-<version>-documentation.zip`
 - E.g https://buchel.family/repository/wml/first/WML-Core/WML-Core-Docs/latest/WML-Core-Docs-latest-documentation.zip
 
-- You can naviage these docs and files manually too via https://buchel.family/repository/wml/first/
+- You can also naviage the files and docs manually via https://buchel.family/repository/wml/first/
 
 ### Library examples
 - Added to the library is an [example folder](/examples/). More examples are planned, however, I am aware that there are not many examples currently (especially compared to the breadth of the content in the library).
 
-- I recommend looking at code that uses the library to get a better idea of what to do. (e.g. The Build environment we use for testing [Src](Robot/src/main))
-
+- I recommend looking at code that uses the library to get a better idea of what to do. (e.g. CurtinFRC's code -> [Code](https://github.com/CurtinFRC/2021-GameChangers))
 
 ## Contributing to WML
 [CONTRIBUTING.md](CONTRIBUTING.md)
 
 
-<sub><sup>readme written by [@CJBuchel](https://github.com/CJBuchel), 30/10/21</sup></sub>
+<sub><sup>readme written by [@CJBuchel](https://github.com/CJBuchel), 20/12/21</sup></sub>

--- a/UDP_TransferNT/build.gradle
+++ b/UDP_TransferNT/build.gradle
@@ -3,7 +3,7 @@ ext {
 	req_proj_libs = []
 	req_libs = []
 	lang = 'cpp'
-	projectVersion = '2021.3.1'
+	projectVersion = '2021.3.2'
 	baseUUID = 'd7e51e9d-c0f6-4f51-96f1-cf2beab44a24'
 
 	desktopSupport = true

--- a/WML-Core/build.gradle
+++ b/WML-Core/build.gradle
@@ -3,7 +3,7 @@ ext {
 	req_proj_libs = []
 	req_libs = []
 	lang = 'cpp'
-	projectVersion = '2021.3.1'
+	projectVersion = '2021.3.2'
 	baseUUID = 'a6d30c03-12a8-476d-8fdc-41dacdb7790f'
 
 	desktopSupport = true

--- a/WML-Rev/build.gradle
+++ b/WML-Rev/build.gradle
@@ -3,7 +3,7 @@ ext {
 	req_proj_libs = ['WML-Core']
 	req_libs = []
 	lang = 'cpp'
-	projectVersion = '2021.3.1'
+	projectVersion = '2021.3.2'
 	baseUUID = '099da10d-4f49-445b-821d-921cd2507f1c'
 
 	desktopSupport = true

--- a/WML-Trajectories/build.gradle
+++ b/WML-Trajectories/build.gradle
@@ -3,7 +3,7 @@ ext {
 	req_proj_libs = []
 	req_libs = []
 	lang = 'cpp'
-	projectVersion = '2021.3.1'
+	projectVersion = '2021.3.2'
 	baseUUID = '99d9ec36-9d96-4cbb-819d-836e8614a9fb'
 
 	desktopSupport = true

--- a/config.gradle
+++ b/config.gradle
@@ -1,7 +1,7 @@
 ext {
 	// Maven URLs
-	mavenPublishURL = "https://buchel.family/repository/wml" // maven only publishes via secure lines
-	mavenClientURL = "http://buchel.family/repository/wml" // client maven only works without ssl security
+	mavenURL = "https://buchel.family/repository/wml" // maven only publishes via secure lines
+	// mavenURL = "http://buchel.family/repository/wml" // client maven only works without ssl security
 	outputFolder = file("$rootProject.buildDir/outputs")
 
 	licenseFile = file("$rootDir/LICENSE")

--- a/shared/publish.gradle
+++ b/shared/publish.gradle
@@ -10,13 +10,12 @@ publishing {
 			if (localMaven) {
 				println "${nativeName}: Using Local Maven"
 				name = "all_wml_maven"
-				mavenPublishURL = "${rootProject.buildDir}/maven"
-				mavenClientURL = mavenPublishURL
-				url = mavenPublishURL
+				mavenURL = "${rootProject.buildDir}/maven"
+				url = mavenURL
 			} else {
 				println "${nativeName}: Using Remote maven - I sure hope you know what your doing"
-				println "Publishing to: ${mavenPublishURL}"
-				url = mavenPublishURL
+				println "Publishing to: ${mavenURL}"
+				url = mavenURL
 				credentials {
 					username = project.getProperty("publish_user")
 					password = project.getProperty("publish_pass")

--- a/shared/vendor.gradle
+++ b/shared/vendor.gradle
@@ -7,10 +7,10 @@ Map<String, Object> vendorJson() {
 		version: artifactVersion,
 		uuid: "${artifactUUID}",
 		mavenUrls: [
-			mavenClientURL
+			mavenURL
 		],
 
-		jsonUrl: "${mavenClientURL}/${artifactGroupID_URL}/${depsName}/${artifactVersion}/${depsName}-${artifactVersion}.json",
+		jsonUrl: "${mavenURL}/${artifactGroupID_URL}/${depsName}/${artifactVersion}/${depsName}-${artifactVersion}.json",
 		cppDependencies: [
 			cpp_optionalDependencies
 		]
@@ -24,10 +24,10 @@ Map<String, Object> vendorJsonLatest() {
 		version: artifactVersion,
 		uuid: "${artifactUUID}",
 		mavenUrls: [
-			mavenClientURL
+			mavenURL
 		],
 
-		jsonUrl: "${mavenClientURL}/${artifactGroupID_URL}/${depsName}/latest/${depsName}-latest.json",
+		jsonUrl: "${mavenURL}/${artifactGroupID_URL}/${depsName}/latest/${depsName}-latest.json",
 		cppDependencies: [
 			cpp_optionalDependencies
 		]


### PR DESCRIPTION
**What this PR does**  
GradleRIO made an update for the new gradle 7+ line up. All vendors now require to be https.
(I would have done it anyway if they didn't block using https until now... but whatever)

Fixes up the url string for creating the new .json's with https link.
Also switches the version from `2021.3.1` to `2021.3.2` note that this is only the project version, to signify the protocol change.
The gradlerio version is still running as 2021.3.1