### PR TITLE
Update to strategies to support passive strategies and fix arg refere…

### DIFF
--- a/WML-Core/build.gradle
+++ b/WML-Core/build.gradle
@@ -3,7 +3,7 @@ ext {
   req_proj_libs = []
   req_libs = []
   lang = 'cpp'
-  projectVersion = '2022.2.1-1'
+  projectVersion = '2022.2.1-2'
   baseUUID = 'a6d30c03-12a8-476d-8fdc-41dacdb7790f'
 
   desktopSupport = true

--- a/WML-Core/src/main/cpp/strategy/StrategyController.cpp
+++ b/WML-Core/src/main/cpp/strategy/StrategyController.cpp
@@ -69,6 +69,7 @@ bool StrategyController::DoSchedule(std::shared_ptr<Strategy> strategy, bool for
     throw std::invalid_argument("Cannot reuse a Strategy that has SetCanBeReused(false)");
   }
 
+
   // Assert that systems exist, and that they may have an interrupted strategy
   for (StrategySystem *sys : strategy->GetRequirements()) {
     if (std::find(_impl->systems.begin(), _impl->systems.end(), sys) == _impl->systems.end()) {

--- a/WML-Core/src/main/include/strategy/Strategy.h
+++ b/WML-Core/src/main/include/strategy/Strategy.h
@@ -84,6 +84,15 @@ class Strategy {
   }
 
   /**
+   * Set whether this Strategy is passive. Passive strategies have no concept of being 'done', 
+   * but are cancelled immediately if all other strategies in the current queue, e.g. spinning
+   * up a flywheel while following a path. Passive strategies only exist within queues.
+   */
+  void SetPassive(bool passive) {
+    _is_passive = passive;
+  }
+
+  /**
    * Get whether this Strategy can be interrupted by other Strategies.
    */
   bool CanBeInterrupted() {
@@ -183,7 +192,7 @@ class Strategy {
   }
 
   void Update(double dt) {
-    if (_strategy_state != StrategyState::RUNNING) {
+    if (_strategy_state == StrategyState::INITIALIZED) {
       Start();
     }
 
@@ -215,6 +224,7 @@ class Strategy {
   double _timeout = 0;
   bool _can_reuse = false;
   bool _can_interrupt = false;
+  bool _is_passive = false;
   StrategyState _strategy_state = StrategyState::INITIALIZED;
 
   wpi::SmallSet<StrategySystem *, 8> _requirements;

--- a/WML-Core/src/main/include/strategy/StrategyBuilder.h
+++ b/WML-Core/src/main/include/strategy/StrategyBuilder.h
@@ -38,7 +38,7 @@ class StrategyBuilder {
    * Parallel actions may not share the same system, they must be mutually exclusive.
    */
   template<typename T, typename ...Args>
-  StrategyBuilder *Add(const Args ... args) {
+  StrategyBuilder *Add(const Args& ... args) {
     return Add(std::make_shared<T>(args...));
   }
 

--- a/WML-Core/src/test/cpp/test_Strategy.cpp
+++ b/WML-Core/src/test/cpp/test_Strategy.cpp
@@ -264,7 +264,12 @@ TEST_F(StrategyTest, ThrowsIfReuseFalse) {
   strat->Requires(&sysA);
 
   ASSERT_TRUE(controller.Schedule(strat));
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::RUNNING);
+  strat->SetDone();
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::DONE);
+  controller.Update();
   ASSERT_THROW(controller.Schedule(strat), std::invalid_argument);
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::DONE);
 }
 
 TEST_F(StrategyTest, AllowReuseIfTrue) {
@@ -275,5 +280,10 @@ TEST_F(StrategyTest, AllowReuseIfTrue) {
   strat->Requires(&sysA);
 
   ASSERT_TRUE(controller.Schedule(strat));
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::RUNNING);
+  strat->SetDone();
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::DONE);
+  controller.Update();
   ASSERT_NO_THROW(controller.Schedule(strat));
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::RUNNING);
 }


### PR DESCRIPTION
Update Strategies to support passive (background) strategies and, prevent strategies from continuing to run when done in a parallel queue, and allow arg references in StrategyBuilder::Add for non-copyable and non-movable types. StrategyQueue also now appends currently running strategies to its name.